### PR TITLE
Add Paqmind learning platform to JS section

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ YAY!
 * http://jsforcats.com/ - A+ short intro.
 * Interactive code lessons [Node School](https://nodeschool.io), some of which cover basic and advanced JS.
 * Coderbyte - toy problems to practice your JavaScript (or any language) skills. (http://coderbyte.com/CodingArea/Challenges/).
+* [Paqmind](http://paqmind.com) - learning platform dedicated to programming and web development. Hundreds of exercises with solutions and explanations.
 * [JavaScriptIsSexy](http://javascriptissexy.com/) has some good information about JavaScript in some depth. For example, here's a post on scope and hoisting [here](http://javascriptissexy.com/javascript-variable-scope-and-hoisting-explained/).
 * [Learn JavaScript Design Patterns](http://www.addyosmani.com/resources/essentialjsdesignpatterns/book/)
 * Clearinghouse of JavaScript resources - [Superhero.js](http://superherojs.com/).


### PR DESCRIPTION
Hello!

Can I suggest to add Paqmind learning platform to your list of resources?
The platform is mostly web-dev oriented and uses JavaScript as the main language.

At the moment, there are 3 free courses for beginners:
* Programming
* Functional Programming
* NodeJS

Altogether it has 300+ exercises with solutions and explanations and we plan to add more courses on subjects like NodeJS, ReactJS, Functional Programming, Reactivity, Asynchronicity and all JavaScript-related.

P.S. I was not sure about the order you use in the list and added a new link right after NodeSchool and Coderbyte, as they have a bit similar idea.